### PR TITLE
Replace global rand with std::mt19937 in Louvain

### DIFF
--- a/CPP/cliques/louvain_gen.h
+++ b/CPP/cliques/louvain_gen.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+#include <random>
 #include <vector>
 #include "graphhelpers.h"
 #include "stability_gen.h"
@@ -145,7 +147,8 @@ vec2 create_reduced_null_model_vec( std::map<int, int> new_comm_id_to_old_comm_i
 template<typename P, typename T, typename W, typename QF, typename QFDIFF>
 double find_optimal_partition_louvain_gen( T& graph, W& weights, vec2 null_model_vec,
         QF compute_quality, QFDIFF compute_quality_diff, P initial_partition,
-        std::vector<P>& optimal_partitions, double minimum_improve )
+        std::vector<P>& optimal_partitions, double minimum_improve,
+        std::mt19937& rng )
 {
 
     typedef typename T::Node Node;
@@ -166,9 +169,7 @@ double find_optimal_partition_louvain_gen( T& graph, W& weights, vec2 null_model
     //clq::print_partition_list( partition );
     //clq::output( "end partition list \n" );
 
-    // Randomise the looping over nodes. You should nitialise random number generator
-    // outside louvain when calling externally multiple times!
-    // srand(std::time(0));
+    // Randomise the looping over nodes using the caller-provided RNG.
     std::vector<Node> nodes_ordered_randomly;
 
     for( NodeIt temp_node( graph ); temp_node != lemon::INVALID; ++temp_node ) {
@@ -176,7 +177,7 @@ double find_optimal_partition_louvain_gen( T& graph, W& weights, vec2 null_model
     }
 
     //clq::output( "Reshuffling ", lemon::countNodes( graph ), "Nodes" );
-    std::random_shuffle( nodes_ordered_randomly.begin(), nodes_ordered_randomly.end() );
+    std::shuffle( nodes_ordered_randomly.begin(), nodes_ordered_randomly.end(), rng );
     //clq::output( "Reshuffling done" );
 
     do {
@@ -226,7 +227,7 @@ double find_optimal_partition_louvain_gen( T& graph, W& weights, vec2 null_model
 
     // 2) If there has actually been some movement, then we need to assemble a new graph
     if( do_construct_new_graph == true ) {
-        // Compile P into original partition size. If there has been a move, then we 
+        // Compile P into original partition size. If there has been a move, then we
         // want to store the intermediate result of the Louvain method. If there has been no move, then the
         // partition in the previous level was optimal.
         P partition_original_nodes = fold_partition_into_orginal_graph_size( optimal_partitions, partition );
@@ -234,7 +235,7 @@ double find_optimal_partition_louvain_gen( T& graph, W& weights, vec2 null_model
         //clq::output("Optimal partition: ", optimal_partitions.size());
         //clq::print_partition_list( partition );
         //clq::output( "renormalized partition above; now starting second phase" );
-        
+
         //clq::output( "Constructing new graph" );
         // Create graph from partition
         T reduced_graph;
@@ -254,7 +255,7 @@ double find_optimal_partition_louvain_gen( T& graph, W& weights, vec2 null_model
         //clq::print_2d_vector( reduced_null_model_vec );
 
         return find_optimal_partition_louvain_gen( reduced_graph,reduced_weights,reduced_null_model_vec,compute_quality,
-                compute_quality_diff,reduced_partition,optimal_partitions, minimum_improve );
+                compute_quality_diff,reduced_partition,optimal_partitions, minimum_improve, rng );
     } else {
         //clq::output( "Reached bottom", current_quality );
         if (optimal_partitions.size() == 0){
@@ -282,9 +283,10 @@ double find_optimal_partition_louvain_gen( T& graph, W& weights, vec2 null_model
 
  */
 template<typename P, typename T, typename W, typename QF, typename QFDIFF>
-double find_optimal_partition_louvain( T& graph, W& weights, 
+double find_optimal_partition_louvain( T& graph, W& weights,
         QF compute_quality, QFDIFF compute_quality_diff, P initial_partition,
-        std::vector<P>& optimal_partitions, double minimum_improve )
+        std::vector<P>& optimal_partitions, double minimum_improve,
+        std::mt19937& rng )
 {
 
     typedef typename T::Node Node;
@@ -310,9 +312,7 @@ double find_optimal_partition_louvain( T& graph, W& weights,
     //clq::print_partition_list( partition );
     //clq::output( "end partition list \n" );
 
-    // Randomise the looping over nodes. You should nitialise random number generator
-    // outside louvain when calling externally multiple times!
-    // srand(std::time(0));
+    // Randomise the looping over nodes using the caller-provided RNG.
     std::vector<Node> nodes_ordered_randomly;
 
     for( NodeIt temp_node( graph ); temp_node != lemon::INVALID; ++temp_node ) {
@@ -320,7 +320,7 @@ double find_optimal_partition_louvain( T& graph, W& weights,
     }
 
     //clq::output( "Reshuffling ", lemon::countNodes( graph ), "Nodes" );
-    std::random_shuffle( nodes_ordered_randomly.begin(), nodes_ordered_randomly.end() );
+    std::shuffle( nodes_ordered_randomly.begin(), nodes_ordered_randomly.end(), rng );
     //clq::output( "Reshuffling done" );
 
     do {
@@ -395,14 +395,40 @@ double find_optimal_partition_louvain( T& graph, W& weights,
         //clq::print_2d_vector( reduced_null_model_vec );
 
         return find_optimal_partition_louvain( reduced_graph,reduced_weights,compute_quality,
-                compute_quality_diff,reduced_partition,optimal_partitions, minimum_improve );
+                compute_quality_diff,reduced_partition,optimal_partitions, minimum_improve, rng );
     } else {
         //clq::output( "Reached bottom", current_quality );
         if (optimal_partitions.size() == 0){
             optimal_partitions.push_back(partition);
         }
         return current_quality;
-    }    
+    }
+}
+
+
+// Backwards-compatible overloads: if no RNG is supplied, fall back to a
+// thread-local std::mt19937 seeded from std::random_device. This preserves
+// the old call signature for existing callers.
+template<typename P, typename T, typename W, typename QF, typename QFDIFF>
+double find_optimal_partition_louvain_gen( T& graph, W& weights, vec2 null_model_vec,
+        QF compute_quality, QFDIFF compute_quality_diff, P initial_partition,
+        std::vector<P>& optimal_partitions, double minimum_improve )
+{
+    static thread_local std::mt19937 default_rng{ std::random_device{}() };
+    return find_optimal_partition_louvain_gen( graph, weights, null_model_vec,
+            compute_quality, compute_quality_diff, initial_partition,
+            optimal_partitions, minimum_improve, default_rng );
+}
+
+template<typename P, typename T, typename W, typename QF, typename QFDIFF>
+double find_optimal_partition_louvain( T& graph, W& weights,
+        QF compute_quality, QFDIFF compute_quality_diff, P initial_partition,
+        std::vector<P>& optimal_partitions, double minimum_improve )
+{
+    static thread_local std::mt19937 default_rng{ std::random_device{}() };
+    return find_optimal_partition_louvain( graph, weights,
+            compute_quality, compute_quality_diff, initial_partition,
+            optimal_partitions, minimum_improve, default_rng );
 }
 
 

--- a/CPP/cliques/run_gen_louvain.cpp
+++ b/CPP/cliques/run_gen_louvain.cpp
@@ -4,6 +4,8 @@
 #include "io.h"
 
 #include <lemon/smart_graph.h>
+#include <ctime>
+#include <random>
 #include <vector>
 
 // Call generic Louvain optimisation from command line
@@ -11,12 +13,10 @@
 // Example: ./run_gen_louvain.sh graph_file null_model_file time random_seed
 int main(int argc, char *argv []) {
 
-    // initialise random seed from input
-    if (argc < 5) {
-        srand(time(0));
-    } else {
-        srand(atoi(argv[4]));
-    }
+    // initialise random number generator from input
+    unsigned int seed = (argc < 5) ? static_cast<unsigned int>(std::time(nullptr))
+                                   : static_cast<unsigned int>(std::atoi(argv[4]));
+    std::mt19937 rng(seed);
 
     // initialise markov time from input
     double current_markov_time = 1;
@@ -54,7 +54,7 @@ int main(int argc, char *argv []) {
     clq::output("Start Louvain");
     double stability = clq::find_optimal_partition_louvain_gen<partition>(
                            input_graph, input_graph_weights, null_model, quality, quality_gain,
-                           start_partition, optimal_partitions, 1e-18);
+                           start_partition, optimal_partitions, 1e-18, rng);
     
     // store output partitions in file
     clq::partitions_to_file("optimal_partitions.dat", optimal_partitions);


### PR DESCRIPTION
Thread an explicit std::mt19937& through find_optimal_partition_louvain_gen and find_optimal_partition_louvain so callers control the RNG, and replace std::random_shuffle (deprecated, removed in C++17) with std::shuffle. The CLI driver now constructs std::mt19937 from argv[4] (or std::time when no seed is given) instead of calling srand.

Add backwards-compatible overloads without the rng parameter that fall back to a thread-local std::mt19937 seeded from std::random_device, so existing callers continue to compile unchanged.