### PR TITLE
Use portable Fisher-Yates instead of std::shuffle

### DIFF
--- a/CPP/cliques/louvain_gen.h
+++ b/CPP/cliques/louvain_gen.h
@@ -177,7 +177,13 @@ double find_optimal_partition_louvain_gen( T& graph, W& weights, vec2 null_model
     }
 
     //clq::output( "Reshuffling ", lemon::countNodes( graph ), "Nodes" );
-    std::shuffle( nodes_ordered_randomly.begin(), nodes_ordered_randomly.end(), rng );
+    // Portable Fisher-Yates: bit-identical across libstdc++/libc++ given the
+    // same mt19937 state. std::shuffle's internal distribution is
+    // implementation-defined and would diverge between platforms.
+    for( std::size_t i = nodes_ordered_randomly.size(); i > 1; --i ) {
+        std::size_t j = rng() % i;
+        std::swap( nodes_ordered_randomly[j], nodes_ordered_randomly[i - 1] );
+    }
     //clq::output( "Reshuffling done" );
 
     do {
@@ -320,7 +326,13 @@ double find_optimal_partition_louvain( T& graph, W& weights,
     }
 
     //clq::output( "Reshuffling ", lemon::countNodes( graph ), "Nodes" );
-    std::shuffle( nodes_ordered_randomly.begin(), nodes_ordered_randomly.end(), rng );
+    // Portable Fisher-Yates: bit-identical across libstdc++/libc++ given the
+    // same mt19937 state. std::shuffle's internal distribution is
+    // implementation-defined and would diverge between platforms.
+    for( std::size_t i = nodes_ordered_randomly.size(); i > 1; --i ) {
+        std::size_t j = rng() % i;
+        std::swap( nodes_ordered_randomly[j], nodes_ordered_randomly[i - 1] );
+    }
     //clq::output( "Reshuffling done" );
 
     do {


### PR DESCRIPTION
Follow-up to #1 (which merged the std::mt19937 plumbing).

`std::shuffle`'s internal `uniform_int_distribution` is implementation-defined, so libstdc++ (Linux/gcc) and libc++ (macOS/clang) produce different orderings from the same `mt19937` state. This leaks across platforms even with deterministic seeds and made test fixtures regenerated on macOS fail strict comparison on Linux CI in PyGenStability.

A hand-rolled Fisher-Yates that consumes `mt19937` output directly via `rng() % i` is modulo-biased but bit-identical across compilers — exactly what's needed for reproducible test fixtures.

Diff is two `std::shuffle` call sites in `CPP/cliques/louvain_gen.h` replaced with the same inline loop. No public-API change, no behavior change beyond determinism.